### PR TITLE
9 of 28 examples were invalid: they used 3-digit language codes

### DIFF
--- a/www/meta/kernel-2.1/example/datacite-metadata-sample-v2.1.xml
+++ b/www/meta/kernel-2.1/example/datacite-metadata-sample-v2.1.xml
@@ -32,7 +32,7 @@
 		<date dateType="Valid">2005-04-05</date>
 		<date dateType="Accepted">2005-01-01</date>
 	</dates>
-	<language>eng</language>
+	<language>en</language>
 	<resourceType resourceTypeGeneral="Image">Animation</resourceType>
 	<alternateIdentifiers>
 		<alternateIdentifier alternateIdentifierType="ISBN">937-0-1234-56789-X</alternateIdentifier>

--- a/www/meta/kernel-2.2/example/datacite-metadata-sample-article-v2.2.xml
+++ b/www/meta/kernel-2.2/example/datacite-metadata-sample-article-v2.2.xml
@@ -17,7 +17,7 @@
 	<subjects>
 		<subject subjectScheme="DDC">550 Earth sciences and geology</subject>
 	</subjects>
-	<language>eng</language>
+	<language>en</language>
 	<resourceType resourceTypeGeneral="Text">Article</resourceType>
 	<formats>
 		<format>PDF</format>

--- a/www/meta/kernel-2.2/example/datacite-metadata-sample-complicated-v2.2.xml
+++ b/www/meta/kernel-2.2/example/datacite-metadata-sample-complicated-v2.2.xml
@@ -30,7 +30,7 @@
 		<date dateType="StartDate">2009-04-29</date>
 		<date dateType="EndDate">2010-01-05</date>
 	</dates>
-	<language>GER</language>
+	<language>DE</language>
 	<resourceType resourceTypeGeneral="Text">Monograph</resourceType>
 	<alternateIdentifiers>
 		<alternateIdentifier alternateIdentifierType="ISBN">937-0-4523-12357-6</alternateIdentifier>

--- a/www/meta/kernel-2.2/example/datacite-metadata-sample-v2.2.xml
+++ b/www/meta/kernel-2.2/example/datacite-metadata-sample-v2.2.xml
@@ -32,7 +32,7 @@
 		<date dateType="Valid">2005-04-05</date>
 		<date dateType="Accepted">2005-01-01</date>
 	</dates>
-	<language>eng</language>
+	<language>en</language>
 	<resourceType resourceTypeGeneral="Image">Animation</resourceType>
 	<alternateIdentifiers>
 		<alternateIdentifier alternateIdentifierType="ISBN">937-0-1234-56789-X</alternateIdentifier>

--- a/www/meta/kernel-2.2/example/datacite-metadata-sample-video-v2.2.xml
+++ b/www/meta/kernel-2.2/example/datacite-metadata-sample-video-v2.2.xml
@@ -19,7 +19,7 @@
 			<contributorName>Technische Informationsbibliothek (TIB)</contributorName>
 		</contributor>
 	</contributors>
-	<language>ger</language>
+	<language>de</language>
 	<resourceType resourceTypeGeneral="Film"/>
 	<formats>
 		<format>MP4</format>

--- a/www/meta/kernel-2.3/example/datacite-metadata-sample-article-v2.3.xml
+++ b/www/meta/kernel-2.3/example/datacite-metadata-sample-article-v2.3.xml
@@ -17,7 +17,7 @@
 	<subjects>
 		<subject subjectScheme="DDC">550 Earth sciences and geology</subject>
 	</subjects>
-	<language>eng</language>
+	<language>en</language>
 	<resourceType resourceTypeGeneral="Text">Article</resourceType>
 	<formats>
 		<format>PDF</format>

--- a/www/meta/kernel-2.3/example/datacite-metadata-sample-complicated-v2.3.xml
+++ b/www/meta/kernel-2.3/example/datacite-metadata-sample-complicated-v2.3.xml
@@ -30,7 +30,7 @@
 		<date dateType="StartDate">2009-04-29</date>
 		<date dateType="EndDate">2010-01-05</date>
 	</dates>
-	<language>GER</language>
+	<language>DE</language>
 	<resourceType resourceTypeGeneral="Text">Monograph</resourceType>
 	<alternateIdentifiers>
 		<alternateIdentifier alternateIdentifierType="ISBN">937-0-4523-12357-6</alternateIdentifier>

--- a/www/meta/kernel-2.3/example/datacite-metadata-sample-v2.3.xml
+++ b/www/meta/kernel-2.3/example/datacite-metadata-sample-v2.3.xml
@@ -32,7 +32,7 @@
 		<date dateType="Valid">2005-04-05</date>
 		<date dateType="Accepted">2005-01-01</date>
 	</dates>
-	<language>eng</language>
+	<language>en</language>
 	<resourceType resourceTypeGeneral="Image">Animation</resourceType>
 	<alternateIdentifiers>
 		<alternateIdentifier alternateIdentifierType="ISBN">937-0-1234-56789-X</alternateIdentifier>

--- a/www/meta/kernel-2.3/example/datacite-metadata-sample-video-v2.3.xml
+++ b/www/meta/kernel-2.3/example/datacite-metadata-sample-video-v2.3.xml
@@ -19,7 +19,7 @@
 			<contributorName>Technische Informationsbibliothek (TIB)</contributorName>
 		</contributor>
 	</contributors>
-	<language>ger</language>
+	<language>de</language>
 	<resourceType resourceTypeGeneral="Film"/>
 	<formats>
 		<format>MP4</format>


### PR DESCRIPTION
Surprisingly to me, XML Schema validation tools (I tried xmlstarlet and xmllint which are based on libxml2) complained about those example XML instances which used 3-digit language codes for the `<language>` element, e.g.:

``` bash
[schema/www/meta/kernel-2.2]$ xmlstarlet val --err --xsd metadata.xsd example/datacite-metadata-sample-article-v2.2.xml
example/datacite-metadata-sample-article-v2.2.xml:20: element language: Schemas validity error : Element '{http://datacite.org/schema/kernel-2.2}language': 'eng' is not a valid value of the atomic type 'xs:language'.
example/datacite-metadata-sample-article-v2.2.xml - invalid
```

Of course, validators can be wrong, so I checked the relevant standards and technical recommendations. The current [XML Schema TR](http://www.w3.org/TR/xmlschema-2/#language) refers to [RFC 3066](https://www.ietf.org/rfc/rfc3066.txt) which states:

```
   2. When a language has both an ISO 639-1 2-character code and an ISO
      639-2 3-character code, you MUST use the tag derived from the ISO
      639-1 2-character code.
```

So I made the necessary changes to the example XML files that were reported as invalid. Unfortunately I cannot update the PDF documentation because their sources are not included (and you seem to use M$ Word).
