### PR TITLE
JSONSchema fixes

### DIFF
--- a/source/json/kernel-4.2/datacite_4.2_schema.json
+++ b/source/json/kernel-4.2/datacite_4.2_schema.json
@@ -471,7 +471,6 @@
         "publisher",
         "publicationYear",
         "types",
-        "schemaVersion",
-        "agency"
+        "schemaVersion"
     ]
 }

--- a/source/json/kernel-4.2/datacite_4.2_schema.json
+++ b/source/json/kernel-4.2/datacite_4.2_schema.json
@@ -238,7 +238,8 @@
                     "givenName": {"type": "string"},
                     "familyName": {"type": "string"},
                     "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
-                    "affiliations": {"$ref": "#/definitions/affiliations"}
+                    "affiliations": {"$ref": "#/definitions/affiliations"},
+                    "lang": {"type": "string"}
                 },
                 "required": ["name"]
             },
@@ -292,7 +293,8 @@
                     "givenName": {"type": "string"},
                     "familyName": {"type": "string"},
                     "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
-                    "affiliations": {"$ref": "#/definitions/affiliations"}
+                    "affiliations": {"$ref": "#/definitions/affiliations"},
+                    "lang": {"type": "string"}
                 },
                 "required": ["contributorType", "name"]
             },

--- a/source/json/kernel-4.2/datacite_4.2_schema.json
+++ b/source/json/kernel-4.2/datacite_4.2_schema.json
@@ -70,7 +70,7 @@
         },
         "date": {
             "type": "string",
-            "oneOf": [
+            "anyOf": [
                 {"format": "year"},
                 {"format": "yearmonth"},
                 {"format": "date"},

--- a/source/json/kernel-4.2/datacite_4.2_schema.json
+++ b/source/json/kernel-4.2/datacite_4.2_schema.json
@@ -460,10 +460,6 @@
         "schemaVersion": {
             "type": "string",
             "const": "http://datacite.org/schema/kernel-4"
-        },
-        "agency": {
-            "type": "string",
-            "enum": ["DataCite"]
         }
     },
 

--- a/source/json/kernel-4.2/datacite_4.2_schema.json
+++ b/source/json/kernel-4.2/datacite_4.2_schema.json
@@ -432,7 +432,8 @@
                                     "minItems": 4
                                 },
                                 "inPolygonPoint": {"$ref": "#/definitions/geoLocationPoint"}
-                            }
+                            },
+                            "required": ["polygonPoints"]
                         },
                         "uniqueItems": true
                     }

--- a/source/json/kernel-4.2/example/datacite-example-Box_dateCollected_DataCollector-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-Box_dateCollected_DataCollector-v4.json
@@ -71,12 +71,12 @@
   ],
   "publicationYear": "1963",
   "language": "en",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/datacollector_datecollected_geolocationbox"
+      "identifier": "10.5072/datacollector_datecollected_geolocationbox"
     }
-  ],
+  ,
   "sizes": [
     "10 p."
   ],

--- a/source/json/kernel-4.2/example/datacite-example-GeoLocation-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-GeoLocation-v4.json
@@ -3,6 +3,7 @@
   "doi": "10.5072/geopointexample",
   "types": {
     "resourceTypeGeneral": "Dataset",
+    "resourceType": "Dataset",
     "schemaOrg": "Dataset",
     "citeproc": "dataset",
     "bibtex": "misc",
@@ -47,7 +48,8 @@
   "contributors": [
     {
       "nameType": "Organizational",
-      "name": "         IFM-GEOMAR Leibniz-Institute Of Marine Sciences, Kiel University       "
+      "name": "IFM-GEOMAR Leibniz-Institute Of Marine Sciences, Kiel University",
+      "contributorType": "ResearchGroup"
     }
   ],
   "dates": [
@@ -58,12 +60,12 @@
   ],
   "publicationYear": "2011",
   "language": "en",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/geopointexample"
+      "identifier": "10.5072/geopointexample"
     }
-  ],
+  ,
   "sizes": [
     "4 datasets"
   ],

--- a/source/json/kernel-4.2/example/datacite-example-HasMetadata-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-HasMetadata-v4.json
@@ -74,7 +74,8 @@
   "contributors": [
     {
       "nameType": "Organizational",
-      "name": "INIST-CNRS"
+      "name": "INIST-CNRS",
+      "contributorType":"ResearchGroup"
     }
   ],
   "dates": [
@@ -85,12 +86,12 @@
   ],
   "publicationYear": "2010",
   "language": "en",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/example"
+      "identifier": "10.5072/example"
     }
-  ],
+  ,
   "sizes": [
     "183 ko",
     "3 pages"

--- a/source/json/kernel-4.2/example/datacite-example-ResearchGroup_Methods-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-ResearchGroup_Methods-v4.json
@@ -3,6 +3,7 @@
   "doi": "10.5072/fk25h7qrs",
   "types": {
     "resourceTypeGeneral": "Dataset",
+    "resourceType": "Dataset",
     "schemaOrg": "Dataset",
     "citeproc": "dataset",
     "bibtex": "misc",
@@ -60,7 +61,8 @@
   "contributors": [
     {
       "nameType": "Organizational",
-      "name": "Center For Imaging Of Neurodegenerative Disease"
+      "name": "Center For Imaging Of Neurodegenerative Disease",
+      "contributorType": "ResearchGroup"
     }
   ],
   "dates": [
@@ -70,12 +72,12 @@
     }
   ],
   "publicationYear": "2013",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/fk25h7qrs"
+      "identifier": "10.5072/fk25h7qrs"
     }
-  ],
+  ,
   "sizes": [
 
   ],

--- a/source/json/kernel-4.2/example/datacite-example-ResourceTypeGeneral_Collection-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-ResourceTypeGeneral_Collection-v4.json
@@ -53,20 +53,11 @@
   ],
   "publicationYear": "2008",
   "language": "en",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/1003496"
+      "identifier": "10.5072/1003496"
     },
-    {
-      "identifierType": "ADS Grey Lit ID",
-      "identifier": "4335"
-    },
-    {
-      "identifierType": "OASIS ID",
-      "identifier": "suatltd1-48159"
-    }
-  ],
   "sizes": [
     "Doc: 46 kb",
     "PDF: 750 kb",

--- a/source/json/kernel-4.2/example/datacite-example-complicated-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-complicated-v4.json
@@ -71,16 +71,12 @@
   ],
   "publicationYear": "2010",
   "language": "de",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/testpub"
-    },
-    {
-      "identifierType": "ISBN",
-      "identifier": "937-0-4523-12357-6"
+      "identifier": "10.5072/testpub"
     }
-  ],
+  ,
   "sizes": [
     "256 pages"
   ],

--- a/source/json/kernel-4.2/example/datacite-example-datapaper-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-datapaper-v4.json
@@ -65,12 +65,12 @@
   ],
   "publicationYear": "2016",
   "language": "en",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/example-datapaper"
+      "identifier": "10.5072/example-datapaper"
     }
-  ],
+  ,
   "sizes": [
 
   ],

--- a/source/json/kernel-4.2/example/datacite-example-dataset-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-dataset-v4.json
@@ -75,12 +75,12 @@
   ],
   "publicationYear": "2013",
   "language": "en",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/d3p26q35r-test"
+      "identifier": "10.5072/d3p26q35r-test"
     }
-  ],
+  ,
   "sizes": [
 
   ],

--- a/source/json/kernel-4.2/example/datacite-example-full-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-full-v4.json
@@ -75,16 +75,11 @@
   ],
   "publicationYear": "2014",
   "language": "en-US",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/example-full"
+      "identifier": "10.5072/example-full"
     },
-    {
-      "identifierType": "URL",
-      "identifier": "https://schema.datacite.org/meta/kernel-4.2/example/datacite-example-full-v4.2.xml"
-    }
-  ],
   "sizes": [
     "4 kB"
   ],

--- a/source/json/kernel-4.2/example/datacite-example-fundingReference-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-fundingReference-v4.json
@@ -3,6 +3,7 @@
   "doi": "10.5281/zenodo.47394",
   "types": {
     "resourceTypeGeneral": "Dataset",
+    "resourceType": "Dataset",
     "schemaOrg": "Dataset",
     "citeproc": "dataset",
     "bibtex": "misc",
@@ -58,16 +59,12 @@
     }
   ],
   "publicationYear": "2016",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5281/zenodo.47394"
-    },
-    {
-      "identifierType": "URL",
-      "identifier": "http://zenodo.org/record/47394"
+      "identifier": "10.5281/zenodo.47394"
     }
-  ],
+  ,
   "sizes": [
 
   ],

--- a/source/json/kernel-4.2/example/datacite-example-polygon-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-polygon-v4.json
@@ -39,12 +39,12 @@
     }
   ],
   "publicationYear": "2017",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/example-polygon"
+      "identifier": "10.5072/example-polygon"
     }
-  ],
+  ,
   "sizes": [
 
   ],

--- a/source/json/kernel-4.2/example/datacite-example-relationTypeisIdenticalTo-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-relationTypeisIdenticalTo-v4.json
@@ -99,7 +99,8 @@
   "contributors": [
     {
       "nameType": "Organizational",
-      "name": "Federal Institute For Population Research"
+      "name": "Federal Institute For Population Research",
+      "contributorType": "ResearchGroup"
     }
   ],
   "dates": [
@@ -110,16 +111,11 @@
   ],
   "publicationYear": "2013",
   "language": "en",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/10.cpos-example"
+      "identifier": "10.5072/10.cpos-example"
     },
-    {
-      "identifierType": "internal ID",
-      "identifier": "da|ra.14.103"
-    }
-  ],
   "sizes": [
 
   ],

--- a/source/json/kernel-4.2/example/datacite-example-software-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-software-v4.json
@@ -91,7 +91,8 @@
   "contributors": [
     {
       "nameType": "Organizational",
-      "name": "Apollo-University Of Cambridge Repository"
+      "name": "Apollo-University Of Cambridge Repository",
+      "contributorType": "ResearchGroup"
     }
   ],
   "dates": [
@@ -106,12 +107,12 @@
   ],
   "publicationYear": "2017",
   "language": "en",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/example-software-2.0"
+      "identifier": "10.5072/example-software-2.0"
     }
-  ],
+  ,
   "sizes": [
 
   ],

--- a/source/json/kernel-4.2/example/datacite-example-video-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-video-v4.json
@@ -48,12 +48,12 @@
   ],
   "publicationYear": "2013",
   "language": "en",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/1153992"
+      "identifier": "10.5072/1153992"
     }
-  ],
+  ,
   "sizes": [
 
   ],

--- a/source/json/kernel-4.2/example/datacite-example-workflow-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-workflow-v4.json
@@ -69,12 +69,12 @@
   ],
   "publicationYear": "2012",
   "language": "en",
-  "identifiers": [
+  "identifier": 
     {
       "identifierType": "DOI",
-      "identifier": "https://doi.org/10.5072/100044"
+      "identifier": "10.5072/100044"
     }
-  ],
+  ,
   "sizes": [
     "31 MB"
   ],


### PR DESCRIPTION
This builds on #55 and found as part of merging inveniosoftware/datacite#48

See the individual commits.

- Add lang attribute to creators and contributors
  - Schema v4.2 added the xml:lang attribute to creators, contributors and publisher properties. In the XML schema this property is on the creatorName/contributorName. This commit is not adding the lang attribute to the publisher property as the solution requires further discussion (#60).
- Require the polygonPoints in geoLocationPolygons
  - According to the v4.2 documentation (18.4.1), the polygon points is a required property if geoLocationPolygons are specified.
- Remove agency property from JSONSchema
  - The agency property is not part of the official v4.2 documentation and thus should not be a required property.