### PR TITLE
Make latitude and longitude values numbers instead of strings

### DIFF
--- a/source/json/kernel-4.2/datacite_4.2_schema.json
+++ b/source/json/kernel-4.2/datacite_4.2_schema.json
@@ -193,10 +193,20 @@
         "geoLocationPoint": {
             "type": "object",
             "properties": {
-                "pointLongitude": {"type": "string", "format": "longitude"},
-                "pointLatitude": {"type": "string", "format": "latitude"}
+                "pointLongitude": {"$ref": "#/definitions/longitude"},
+                "pointLatitude": {"$ref": "#/definitions/latitude"}
             },
             "required": ["pointLongitude", "pointLatitude"]
+        },
+        "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180
+        },
+        "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90
         },
         "funderIdentifierType": {
             "type": "string",
@@ -419,10 +429,10 @@
                     "geoLocationBox": {
                         "type": "object",
                         "properties": {
-                            "westBoundLongitude": {"type": "string", "format": "longitude"},
-                            "eastBoundLongitude": {"type": "string", "format": "longitude"},
-                            "southBoundLatitude": {"type": "string", "format": "latitude"},
-                            "northBoundLatitude": {"type": "string", "format": "latitude"}
+                            "westBoundLongitude": {"$ref": "#/definitions/longitude"},
+                            "eastBoundLongitude": {"$ref": "#/definitions/longitude"},
+                            "southBoundLatitude": {"$ref": "#/definitions/latitude"},
+                            "northBoundLatitude": {"$ref": "#/definitions/latitude"}
                         },
                         "required": ["westBoundLongitude", "eastBoundLongitude", "southBoundLatitude", "northBoundLatitude"]
                     },

--- a/source/json/kernel-4.2/example/datacite-example-Box_dateCollected_DataCollector-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-Box_dateCollected_DataCollector-v4.json
@@ -91,10 +91,10 @@
   "geoLocations": [
     {
       "geoLocationBox": {
-        "westBoundLongitude": "-64.2",
-        "eastBoundLongitude": "-63.8",
-        "southBoundLatitude": "44.7167",
-        "northBoundLatitude": "44.9667"
+        "westBoundLongitude": -64.2,
+        "eastBoundLongitude": -63.8,
+        "southBoundLatitude": 44.7167,
+        "northBoundLatitude": 44.9667
       },
       "geoLocationPlace": "Ponhook Lake, Nova Scotia"
     }

--- a/source/json/kernel-4.2/example/datacite-example-GeoLocation-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-GeoLocation-v4.json
@@ -88,8 +88,8 @@
   "geoLocations": [
     {
       "geoLocationPoint": {
-        "pointLatitude": "69.000000",
-        "pointLongitude": "-52.000000"
+        "pointLatitude": 69.000000,
+        "pointLongitude": -52.000000
       },
       "geoLocationPlace": "Disko Bay"
     }

--- a/source/json/kernel-4.2/example/datacite-example-full-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-full-v4.json
@@ -107,44 +107,44 @@
   "geoLocations": [
     {
       "geoLocationPoint": {
-        "pointLatitude": "31.233",
-        "pointLongitude": "-67.302"
+        "pointLatitude": 31.233,
+        "pointLongitude": -67.302
       },
       "geoLocationBox": {
-        "westBoundLongitude": "-71.032",
-        "eastBoundLongitude": "-68.211",
-        "southBoundLatitude": "41.090",
-        "northBoundLatitude": "42.893"
+        "westBoundLongitude": -71.032,
+        "eastBoundLongitude": -68.211,
+        "southBoundLatitude": 41.090,
+        "northBoundLatitude": 42.893
       },
       "geoLocationPolygon": [
         {
           "polygonPoint": {
-            "pointLatitude": "41.991",
-            "pointLongitude": "-71.032"
+            "pointLatitude": 41.991,
+            "pointLongitude": -71.032
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "42.893",
-            "pointLongitude": "-69.622"
+            "pointLatitude": 42.893,
+            "pointLongitude": -69.622
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "41.991",
-            "pointLongitude": "-68.211"
+            "pointLatitude": 41.991,
+            "pointLongitude": -68.211
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "41.090",
-            "pointLongitude": "-69.622"
+            "pointLatitude": 41.090,
+            "pointLongitude": -69.622
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "41.991",
-            "pointLongitude": "-71.032"
+            "pointLatitude": 41.991,
+            "pointLongitude": -71.032
           }
         }
       ],

--- a/source/json/kernel-4.2/example/datacite-example-polygon-v4.json
+++ b/source/json/kernel-4.2/example/datacite-example-polygon-v4.json
@@ -51,206 +51,206 @@
       "geoLocationPolygon": [
         {
           "polygonPoint": {
-            "pointLongitude": "4.1738852605822",
-            "pointLatitude": "52.03913926329928"
+            "pointLongitude": 4.1738852605822,
+            "pointLatitude": 52.03913926329928
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.177180694215117",
-            "pointLatitude": "52.04164225918711"
+            "pointLongitude": 4.177180694215117,
+            "pointLatitude": 52.04164225918711
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.180535246850687",
-            "pointLatitude": "52.04399625464452"
+            "pointLongitude": 4.180535246850687,
+            "pointLatitude": 52.04399625464452
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.184849833488133",
-            "pointLatitude": "52.04692936720903"
+            "pointLongitude": 4.184849833488133,
+            "pointLatitude": 52.04692936720903
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.188676339698225",
-            "pointLatitude": "52.04967415251541"
+            "pointLongitude": 4.188676339698225,
+            "pointLatitude": 52.04967415251541
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.191534369184121",
-            "pointLatitude": "52.05170714064434"
+            "pointLongitude": 4.191534369184121,
+            "pointLatitude": 52.05170714064434
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.194175770686163",
-            "pointLatitude": "52.05334245636797"
+            "pointLongitude": 4.194175770686163,
+            "pointLatitude": 52.05334245636797
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.195777670597483",
-            "pointLatitude": "52.05421289062893"
+            "pointLongitude": 4.195777670597483,
+            "pointLatitude": 52.05421289062893
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.197318856770764",
-            "pointLatitude": "52.05560708986616"
+            "pointLongitude": 4.197318856770764,
+            "pointLatitude": 52.05560708986616
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.197244535290235",
-            "pointLatitude": "52.05647414552436"
+            "pointLongitude": 4.197244535290235,
+            "pointLatitude": 52.05647414552436
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.194878372206108",
-            "pointLatitude": "52.05558026532434"
+            "pointLongitude": 4.194878372206108,
+            "pointLatitude": 52.05558026532434
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.192275513207293",
-            "pointLatitude": "52.0540037664795"
+            "pointLongitude": 4.192275513207293,
+            "pointLatitude": 52.0540037664795
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.190139539757181",
-            "pointLatitude": "52.05338309097328"
+            "pointLongitude": 4.190139539757181,
+            "pointLatitude": 52.05338309097328
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.188563539343029",
-            "pointLatitude": "52.05409113125509"
+            "pointLongitude": 4.188563539343029,
+            "pointLatitude": 52.05409113125509
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.188843259016792",
-            "pointLatitude": "52.05555708237333"
+            "pointLongitude": 4.188843259016792,
+            "pointLatitude": 52.05555708237333
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.190440325374933",
-            "pointLatitude": "52.05648630398393"
+            "pointLongitude": 4.190440325374933,
+            "pointLatitude": 52.05648630398393
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.193486805620985",
-            "pointLatitude": "52.05721863750948"
+            "pointLongitude": 4.193486805620985,
+            "pointLatitude": 52.05721863750948
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.195782715369962",
-            "pointLatitude": "52.05905125521555"
+            "pointLongitude": 4.195782715369962,
+            "pointLatitude": 52.05905125521555
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.196042562042681",
-            "pointLatitude": "52.0603024859894"
+            "pointLongitude": 4.196042562042681,
+            "pointLatitude": 52.0603024859894
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.194522303279684",
-            "pointLatitude": "52.06042019458354"
+            "pointLongitude": 4.194522303279684,
+            "pointLatitude": 52.06042019458354
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.191569341305619",
-            "pointLatitude": "52.05985079275935"
+            "pointLongitude": 4.191569341305619,
+            "pointLatitude": 52.05985079275935
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.188970128279688",
-            "pointLatitude": "52.05933203100292"
+            "pointLongitude": 4.188970128279688,
+            "pointLatitude": 52.05933203100292
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.185846614849885",
-            "pointLatitude": "52.05849919443985"
+            "pointLongitude": 4.185846614849885,
+            "pointLatitude": 52.05849919443985
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.183766834165052",
-            "pointLatitude": "52.05768273662148"
+            "pointLongitude": 4.183766834165052,
+            "pointLatitude": 52.05768273662148
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.182190558076597",
-            "pointLatitude": "52.05665770545129"
+            "pointLongitude": 4.182190558076597,
+            "pointLatitude": 52.05665770545129
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.180730516454513",
-            "pointLatitude": "52.05512223937299"
+            "pointLongitude": 4.180730516454513,
+            "pointLatitude": 52.05512223937299
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.179642892536666",
-            "pointLatitude": "52.05335222714644"
+            "pointLongitude": 4.179642892536666,
+            "pointLatitude": 52.05335222714644
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.178442502618839",
-            "pointLatitude": "52.05152018985662"
+            "pointLongitude": 4.178442502618839,
+            "pointLatitude": 52.05152018985662
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.1774713992764",
-            "pointLatitude": "52.04954999812316"
+            "pointLongitude": 4.1774713992764,
+            "pointLatitude": 52.04954999812316
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.176346178024046",
-            "pointLatitude": "52.04728138670279"
+            "pointLongitude": 4.176346178024046,
+            "pointLatitude": 52.04728138670279
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.175182683314049",
-            "pointLatitude": "52.04497104660534"
+            "pointLongitude": 4.175182683314049,
+            "pointLatitude": 52.04497104660534
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.173373650824841",
-            "pointLatitude": "52.04226286332442"
+            "pointLongitude": 4.173373650824841,
+            "pointLatitude": 52.04226286332442
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.173204764844041",
-            "pointLatitude": "52.04016615926179"
+            "pointLongitude": 4.173204764844041,
+            "pointLatitude": 52.04016615926179
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.1738852605822",
-            "pointLatitude": "52.03913926329928"
+            "pointLongitude": 4.1738852605822,
+            "pointLatitude": 52.03913926329928
           }
         }
       ],

--- a/source/json/kernel-4.3/datacite_4.3_schema.json
+++ b/source/json/kernel-4.3/datacite_4.3_schema.json
@@ -193,10 +193,20 @@
         "geoLocationPoint": {
             "type": "object",
             "properties": {
-                "pointLongitude": {"type": "string", "format": "longitude"},
-                "pointLatitude": {"type": "string", "format": "latitude"}
+                "pointLongitude": {"$ref": "#/definitions/longitude"},
+                "pointLatitude": {"$ref": "#/definitions/latitude"}
             },
             "required": ["pointLongitude", "pointLatitude"]
+        },
+        "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180
+        },
+        "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90
         },
         "funderIdentifierType": {
             "type": "string",
@@ -419,10 +429,10 @@
                     "geoLocationBox": {
                         "type": "object",
                         "properties": {
-                            "westBoundLongitude": {"type": "string", "format": "longitude"},
-                            "eastBoundLongitude": {"type": "string", "format": "longitude"},
-                            "southBoundLatitude": {"type": "string", "format": "latitude"},
-                            "northBoundLatitude": {"type": "string", "format": "latitude"}
+                            "westBoundLongitude": {"$ref": "#/definitions/longitude"},
+                            "eastBoundLongitude": {"$ref": "#/definitions/longitude"},
+                            "southBoundLatitude": {"$ref": "#/definitions/latitude"},
+                            "northBoundLatitude": {"$ref": "#/definitions/latitude"}
                         },
                         "required": ["westBoundLongitude", "eastBoundLongitude", "southBoundLatitude", "northBoundLatitude"]
                     },

--- a/source/json/kernel-4.3/example/datacite-example-Box_dateCollected_DataCollector-v4.json
+++ b/source/json/kernel-4.3/example/datacite-example-Box_dateCollected_DataCollector-v4.json
@@ -91,10 +91,10 @@
   "geoLocations": [
     {
       "geoLocationBox": {
-        "westBoundLongitude": "-64.2",
-        "eastBoundLongitude": "-63.8",
-        "southBoundLatitude": "44.7167",
-        "northBoundLatitude": "44.9667"
+        "westBoundLongitude": -64.2,
+        "eastBoundLongitude": -63.8,
+        "southBoundLatitude": 44.7167,
+        "northBoundLatitude": 44.9667
       },
       "geoLocationPlace": "Ponhook Lake, Nova Scotia"
     }

--- a/source/json/kernel-4.3/example/datacite-example-GeoLocation-v4.json
+++ b/source/json/kernel-4.3/example/datacite-example-GeoLocation-v4.json
@@ -88,8 +88,8 @@
   "geoLocations": [
     {
       "geoLocationPoint": {
-        "pointLatitude": "69.000000",
-        "pointLongitude": "-52.000000"
+        "pointLatitude": 69.000000,
+        "pointLongitude": -52.000000
       },
       "geoLocationPlace": "Disko Bay"
     }

--- a/source/json/kernel-4.3/example/datacite-example-affiliation-v4.json
+++ b/source/json/kernel-4.3/example/datacite-example-affiliation-v4.json
@@ -161,44 +161,44 @@
   "geoLocations": [
     {
       "geoLocationPoint": {
-        "pointLatitude": "31.233",
-        "pointLongitude": "-67.302"
+        "pointLatitude": 31.233,
+        "pointLongitude": -67.302
       },
       "geoLocationBox": {
-        "westBoundLongitude": "-71.032",
-        "eastBoundLongitude": "-68.211",
-        "southBoundLatitude": "41.090",
-        "northBoundLatitude": "42.893"
+        "westBoundLongitude": -71.032,
+        "eastBoundLongitude": -68.211,
+        "southBoundLatitude": 41.090,
+        "northBoundLatitude": 42.893
       },
       "geoLocationPolygon": [
         {
           "polygonPoint": {
-            "pointLatitude": "41.991",
-            "pointLongitude": "-71.032"
+            "pointLatitude": 41.991,
+            "pointLongitude": -71.032
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "42.893",
-            "pointLongitude": "-69.622"
+            "pointLatitude": 42.893,
+            "pointLongitude": -69.622
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "41.991",
-            "pointLongitude": "-68.211"
+            "pointLatitude": 41.991,
+            "pointLongitude": -68.211
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "41.090",
-            "pointLongitude": "-69.622"
+            "pointLatitude": 41.090,
+            "pointLongitude": -69.622
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "41.991",
-            "pointLongitude": "-71.032"
+            "pointLatitude": 41.991,
+            "pointLongitude": -71.032
           }
         }
       ],

--- a/source/json/kernel-4.3/example/datacite-example-full-v4.json
+++ b/source/json/kernel-4.3/example/datacite-example-full-v4.json
@@ -122,44 +122,44 @@
   "geoLocations": [
     {
       "geoLocationPoint": {
-        "pointLatitude": "31.233",
-        "pointLongitude": "-67.302"
+        "pointLatitude": 31.233,
+        "pointLongitude": -67.302
       },
       "geoLocationBox": {
-        "westBoundLongitude": "-71.032",
-        "eastBoundLongitude": "-68.211",
-        "southBoundLatitude": "41.090",
-        "northBoundLatitude": "42.893"
+        "westBoundLongitude": -71.032,
+        "eastBoundLongitude": -68.211,
+        "southBoundLatitude": 41.090,
+        "northBoundLatitude": 42.893
       },
       "geoLocationPolygon": [
         {
           "polygonPoint": {
-            "pointLatitude": "41.991",
-            "pointLongitude": "-71.032"
+            "pointLatitude": 41.991,
+            "pointLongitude": -71.032
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "42.893",
-            "pointLongitude": "-69.622"
+            "pointLatitude": 42.893,
+            "pointLongitude": -69.622
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "41.991",
-            "pointLongitude": "-68.211"
+            "pointLatitude": 41.991,
+            "pointLongitude": -68.211
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "41.090",
-            "pointLongitude": "-69.622"
+            "pointLatitude": 41.090,
+            "pointLongitude": -69.622
           }
         },
         {
           "polygonPoint": {
-            "pointLatitude": "41.991",
-            "pointLongitude": "-71.032"
+            "pointLatitude": 41.991,
+            "pointLongitude": -71.032
           }
         }
       ],

--- a/source/json/kernel-4.3/example/datacite-example-polygon-v4.json
+++ b/source/json/kernel-4.3/example/datacite-example-polygon-v4.json
@@ -51,206 +51,206 @@
       "geoLocationPolygon": [
         {
           "polygonPoint": {
-            "pointLongitude": "4.1738852605822",
-            "pointLatitude": "52.03913926329928"
+            "pointLongitude": 4.1738852605822,
+            "pointLatitude": 52.03913926329928
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.177180694215117",
-            "pointLatitude": "52.04164225918711"
+            "pointLongitude": 4.177180694215117,
+            "pointLatitude": 52.04164225918711
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.180535246850687",
-            "pointLatitude": "52.04399625464452"
+            "pointLongitude": 4.180535246850687,
+            "pointLatitude": 52.04399625464452
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.184849833488133",
-            "pointLatitude": "52.04692936720903"
+            "pointLongitude": 4.184849833488133,
+            "pointLatitude": 52.04692936720903
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.188676339698225",
-            "pointLatitude": "52.04967415251541"
+            "pointLongitude": 4.188676339698225,
+            "pointLatitude": 52.04967415251541
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.191534369184121",
-            "pointLatitude": "52.05170714064434"
+            "pointLongitude": 4.191534369184121,
+            "pointLatitude": 52.05170714064434
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.194175770686163",
-            "pointLatitude": "52.05334245636797"
+            "pointLongitude": 4.194175770686163,
+            "pointLatitude": 52.05334245636797
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.195777670597483",
-            "pointLatitude": "52.05421289062893"
+            "pointLongitude": 4.195777670597483,
+            "pointLatitude": 52.05421289062893
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.197318856770764",
-            "pointLatitude": "52.05560708986616"
+            "pointLongitude": 4.197318856770764,
+            "pointLatitude": 52.05560708986616
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.197244535290235",
-            "pointLatitude": "52.05647414552436"
+            "pointLongitude": 4.197244535290235,
+            "pointLatitude": 52.05647414552436
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.194878372206108",
-            "pointLatitude": "52.05558026532434"
+            "pointLongitude": 4.194878372206108,
+            "pointLatitude": 52.05558026532434
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.192275513207293",
-            "pointLatitude": "52.0540037664795"
+            "pointLongitude": 4.192275513207293,
+            "pointLatitude": 52.0540037664795
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.190139539757181",
-            "pointLatitude": "52.05338309097328"
+            "pointLongitude": 4.190139539757181,
+            "pointLatitude": 52.05338309097328
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.188563539343029",
-            "pointLatitude": "52.05409113125509"
+            "pointLongitude": 4.188563539343029,
+            "pointLatitude": 52.05409113125509
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.188843259016792",
-            "pointLatitude": "52.05555708237333"
+            "pointLongitude": 4.188843259016792,
+            "pointLatitude": 52.05555708237333
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.190440325374933",
-            "pointLatitude": "52.05648630398393"
+            "pointLongitude": 4.190440325374933,
+            "pointLatitude": 52.05648630398393
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.193486805620985",
-            "pointLatitude": "52.05721863750948"
+            "pointLongitude": 4.193486805620985,
+            "pointLatitude": 52.05721863750948
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.195782715369962",
-            "pointLatitude": "52.05905125521555"
+            "pointLongitude": 4.195782715369962,
+            "pointLatitude": 52.05905125521555
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.196042562042681",
-            "pointLatitude": "52.0603024859894"
+            "pointLongitude": 4.196042562042681,
+            "pointLatitude": 52.0603024859894
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.194522303279684",
-            "pointLatitude": "52.06042019458354"
+            "pointLongitude": 4.194522303279684,
+            "pointLatitude": 52.06042019458354
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.191569341305619",
-            "pointLatitude": "52.05985079275935"
+            "pointLongitude": 4.191569341305619,
+            "pointLatitude": 52.05985079275935
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.188970128279688",
-            "pointLatitude": "52.05933203100292"
+            "pointLongitude": 4.188970128279688,
+            "pointLatitude": 52.05933203100292
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.185846614849885",
-            "pointLatitude": "52.05849919443985"
+            "pointLongitude": 4.185846614849885,
+            "pointLatitude": 52.05849919443985
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.183766834165052",
-            "pointLatitude": "52.05768273662148"
+            "pointLongitude": 4.183766834165052,
+            "pointLatitude": 52.05768273662148
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.182190558076597",
-            "pointLatitude": "52.05665770545129"
+            "pointLongitude": 4.182190558076597,
+            "pointLatitude": 52.05665770545129
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.180730516454513",
-            "pointLatitude": "52.05512223937299"
+            "pointLongitude": 4.180730516454513,
+            "pointLatitude": 52.05512223937299
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.179642892536666",
-            "pointLatitude": "52.05335222714644"
+            "pointLongitude": 4.179642892536666,
+            "pointLatitude": 52.05335222714644
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.178442502618839",
-            "pointLatitude": "52.05152018985662"
+            "pointLongitude": 4.178442502618839,
+            "pointLatitude": 52.05152018985662
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.1774713992764",
-            "pointLatitude": "52.04954999812316"
+            "pointLongitude": 4.1774713992764,
+            "pointLatitude": 52.04954999812316
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.176346178024046",
-            "pointLatitude": "52.04728138670279"
+            "pointLongitude": 4.176346178024046,
+            "pointLatitude": 52.04728138670279
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.175182683314049",
-            "pointLatitude": "52.04497104660534"
+            "pointLongitude": 4.175182683314049,
+            "pointLatitude": 52.04497104660534
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.173373650824841",
-            "pointLatitude": "52.04226286332442"
+            "pointLongitude": 4.173373650824841,
+            "pointLatitude": 52.04226286332442
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.173204764844041",
-            "pointLatitude": "52.04016615926179"
+            "pointLongitude": 4.173204764844041,
+            "pointLatitude": 52.04016615926179
           }
         },
         {
           "polygonPoint": {
-            "pointLongitude": "4.1738852605822",
-            "pointLatitude": "52.03913926329928"
+            "pointLongitude": 4.1738852605822,
+            "pointLatitude": 52.03913926329928
           }
         }
       ],


### PR DESCRIPTION
This also enables us to do away with custom formats "latitude" and "longitude", and validate lats and lons directly in the schema, as in the XSD.

Ref #52