### PR TITLE
Fix typos and prevent them coming in the future

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+# ignore-words-list = 

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = .git,*.pdf,*.svg
+skip = .git,*.pdf,*.svg,*v2.2.xml
 # ignore-words-list = 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,19 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,7 +436,7 @@
 **Closed issues:**
 
 - add more tests [\#25](https://github.com/datacite/schema/issues/25)
-- Adressing version issues in the documentation [\#21](https://github.com/datacite/schema/issues/21)
+- Addressing version issues in the documentation [\#21](https://github.com/datacite/schema/issues/21)
 - Update Citation in Documentation [\#20](https://github.com/datacite/schema/issues/20)
 - integrate testing of non-valid example [\#12](https://github.com/datacite/schema/issues/12)
 - provide changelog for schema versions [\#9](https://github.com/datacite/schema/issues/9)
@@ -485,7 +485,7 @@
 **Closed issues:**
 
 - make html pages valid [\#24](https://github.com/datacite/schema/issues/24)
-- Chage wording in documentation [\#15](https://github.com/datacite/schema/issues/15)
+- Change wording in documentation [\#15](https://github.com/datacite/schema/issues/15)
 
 ## [v.3.1.12](https://github.com/datacite/schema/tree/v.3.1.12) (2016-01-10)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Martin Fenner "mfenner@datacite.org"
 # Set correct environment variables.
 ENV HOME /home/app
 
-# Set env defaults, can be overriden
+# Set env defaults, can be overridden
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV RACK_ENV development

--- a/source/archive/kernel-2.0/metadata.xsd
+++ b/source/archive/kernel-2.0/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
      2010-08-26   Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
 	 2010-11-17 Revised to current state of kernel review, FZ, TIB 
-	 2011-01-17 Complete revsion after community review. FZ, TIB
+	 2011-01-17 Complete revision after community review. FZ, TIB
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" xml:lang="EN">
 	<xs:include schemaLocation="include/datacite-namePart.xsd"/>
@@ -117,7 +117,7 @@
 						<xs:sequence>
 							<xs:element name="contributor" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
 									<xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType mixed="true">

--- a/source/archive/kernel-2.1/metadata.xsd
+++ b/source/archive/kernel-2.1/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
      2010-08-26   Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
 	 2010-11-17 Revised to current state of kernel review, FZ, TIB 
-	 2011-01-17 Complete revsion after community review. FZ, TIB
+	 2011-01-17 Complete revision after community review. FZ, TIB
 	 2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes
 	 IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
 -->
@@ -128,7 +128,7 @@
 						<xs:sequence>
 							<xs:element name="contributor" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
 									<xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType mixed="true">

--- a/source/archive/kernel-2.2/metadata.xsd
+++ b/source/archive/kernel-2.2/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
      2010-08-26   Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
 	 2010-11-17 Revised to current state of kernel review, FZ, TIB 
-	 2011-01-17 Complete revsion after community review. FZ, TIB
+	 2011-01-17 Complete revision after community review. FZ, TIB
 	 2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes
 	 IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
 	 2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
@@ -129,7 +129,7 @@
 						<xs:sequence>
 							<xs:element name="contributor" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
 									<xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType mixed="true">

--- a/source/meta/2008/09/xsd.xsl
+++ b/source/meta/2008/09/xsd.xsl
@@ -176,7 +176,7 @@
   <xsl:apply-templates/>
  </xsl:template>
 
- <!--* 3 Anotation *-->
+ <!--* 3 Annotation *-->
  <xsl:template match="xsd:annotation">
   <xsl:element name="div">
    <xsl:attribute name="class">annotation</xsl:attribute>

--- a/source/meta/kernel-3.0/metadata.xsd
+++ b/source/meta/kernel-3.0/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
      2010-08-26   Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
 	 2010-11-17 Revised to current state of kernel review, FZ, TIB 
-	 2011-01-17 Complete revsion after community review. FZ, TIB
+	 2011-01-17 Complete revision after community review. FZ, TIB
 	 2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes
 	 IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
 	 2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
@@ -134,7 +134,7 @@
 						<xs:sequence>
 							<xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
 									<xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType>

--- a/source/meta/kernel-3.1/metadata.xsd
+++ b/source/meta/kernel-3.1/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
      2010-08-26   Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
 	 2010-11-17 Revised to current state of kernel review, FZ, TIB 
-	 2011-01-17 Complete revsion after community review. FZ, TIB
+	 2011-01-17 Complete revision after community review. FZ, TIB
 	 2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes
 	 IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
 	 2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
@@ -136,7 +136,7 @@
 						<xs:sequence>
 							<xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
 									<xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType>

--- a/source/meta/kernel-3/metadata.xsd
+++ b/source/meta/kernel-3/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
      2010-08-26   Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
 	 2010-11-17 Revised to current state of kernel review, FZ, TIB 
-	 2011-01-17 Complete revsion after community review. FZ, TIB
+	 2011-01-17 Complete revision after community review. FZ, TIB
 	 2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes
 	 IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
 	 2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
@@ -136,7 +136,7 @@
 						<xs:sequence>
 							<xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+									<xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
 									<xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType>

--- a/source/meta/kernel-4.0/metadata.xsd
+++ b/source/meta/kernel-4.0/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
   2010-08-26 Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
   2010-11-17 Revised to current state of kernel review, FZ, TIB
-  2011-01-17 Complete revsion after community review. FZ, TIB
+  2011-01-17 Complete revision after community review. FZ, TIB
   2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
   2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
   2013-07-24 v3.0: namespace: kernel-3.0; delete LastMetadataUpdate & MetadateVersionNumber; additions to controlled lists "contributorType", "dateType", "descriptionType", "relationType", "relatedIdentifierType" & "resourceType"; deletion of "StartDate" & "EndDate" from list "dateType" and "Film" from "resourceType";  allow arbitrary order of elements; allow optional wrapper elements to be empty; include xml:lang attribute for title, subject & description; include attribute schemeURI for nameIdentifier of creator, contributor & subject; added new attributes "relatedMetadataScheme", "schemeURI" & "schemeType" to relatedIdentifier; included new property "geoLocation"
@@ -154,7 +154,7 @@
             <xs:sequence>
               <xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
               <xs:annotation>
-                <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+                <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
                 <xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
               </xs:annotation>
               <xs:complexType>

--- a/source/meta/kernel-4.1/metadata.xsd
+++ b/source/meta/kernel-4.1/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
   2010-08-26 Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
   2010-11-17 Revised to current state of kernel review, FZ, TIB
-  2011-01-17 Complete revsion after community review. FZ, TIB
+  2011-01-17 Complete revision after community review. FZ, TIB
   2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
   2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
   2013-07-24 v3.0: namespace: kernel-3.0; delete LastMetadataUpdate & MetadateVersionNumber; additions to controlled lists "contributorType", "dateType", "descriptionType", "relationType", "relatedIdentifierType" & "resourceType"; deletion of "StartDate" & "EndDate" from list "dateType" and "Film" from "resourceType";  allow arbitrary order of elements; allow optional wrapper elements to be empty; include xml:lang attribute for title, subject & description; include attribute schemeURI for nameIdentifier of creator, contributor & subject; added new attributes "relatedMetadataScheme", "schemeURI" & "schemeType" to relatedIdentifier; included new property "geoLocation"
@@ -161,7 +161,7 @@
             <xs:sequence>
               <xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
               <xs:annotation>
-                <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+                <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
                 <xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
               </xs:annotation>
               <xs:complexType>

--- a/source/meta/kernel-4.2/metadata.xsd
+++ b/source/meta/kernel-4.2/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
   2010-08-26 Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
   2010-11-17 Revised to current state of kernel review, FZ, TIB
-  2011-01-17 Complete revsion after community review. FZ, TIB
+  2011-01-17 Complete revision after community review. FZ, TIB
   2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
   2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
   2013-07-24 v3.0: namespace: kernel-3.0; delete LastMetadataUpdate & MetadateVersionNumber; additions to controlled lists "contributorType", "dateType", "descriptionType", "relationType", "relatedIdentifierType" & "resourceType"; deletion of "StartDate" & "EndDate" from list "dateType" and "Film" from "resourceType";  allow arbitrary order of elements; allow optional wrapper elements to be empty; include xml:lang attribute for title, subject & description; include attribute schemeURI for nameIdentifier of creator, contributor & subject; added new attributes "relatedMetadataScheme", "schemeURI" & "schemeType" to relatedIdentifier; included new property "geoLocation"
@@ -166,7 +166,7 @@
             <xs:sequence>
               <xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
               <xs:annotation>
-                <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+                <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
                 <xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
               </xs:annotation>
               <xs:complexType>

--- a/source/meta/kernel-4.3/metadata.xsd
+++ b/source/meta/kernel-4.3/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
   2010-08-26 Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
   2010-11-17 Revised to current state of kernel review, FZ, TIB
-  2011-01-17 Complete revsion after community review. FZ, TIB
+  2011-01-17 Complete revision after community review. FZ, TIB
   2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
   2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
   2013-07-24 v3.0: namespace: kernel-3.0; delete LastMetadataUpdate & MetadateVersionNumber; additions to controlled lists "contributorType", "dateType", "descriptionType", "relationType", "relatedIdentifierType" & "resourceType"; deletion of "StartDate" & "EndDate" from list "dateType" and "Film" from "resourceType";  allow arbitrary order of elements; allow optional wrapper elements to be empty; include xml:lang attribute for title, subject & description; include attribute schemeURI for nameIdentifier of creator, contributor & subject; added new attributes "relatedMetadataScheme", "schemeURI" & "schemeType" to relatedIdentifier; included new property "geoLocation"
@@ -158,7 +158,7 @@
             <xs:sequence>
               <xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
-                  <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+                  <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
                   <xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
@@ -449,19 +449,19 @@ Use the complete title of a license and include version information if applicabl
       <xs:pattern value="\d{2}(\d{2}|\?\?|\d(\d|\?))(-(\d{2}|\?\?))?~?\??" />
       <!--  
       The following pattern is for  yearMonthDay - yyyymmdd,  where 'dd' may be '??'  so '200412??' means "some day during the month of 12/2004". 
-      The whole  string may be followed by '?' or '~'  to mean "questionable" or "approximate".     Hypens are  not allowed for this pattern. 
+      The whole  string may be followed by '?' or '~'  to mean "questionable" or "approximate".     Hyphens are  not allowed for this pattern. 
       -->
       <xs:pattern value="\d{6}(\d{2}|\?\?)~?\??" />
       <!--  
 
       The following pattern is for date and time with T separator:'yyyymmddThhmmss'. 
-      Hypens in date and colons in time not allowed for this pattern.   
+      Hyphens in date and colons in time not allowed for this pattern.   
       -->
       <xs:pattern value="\d{8}T\d{6}" />
       <!--  
 
       The following pattern is for a date range. in years: 'yyyy/yyyy'; or year/month: yyyy-mm/yyyy-mm, or year/month/day: yyyy-mm-dd/yyyy-mm-dd. Beginning or end of range value may be 'unknown'. End of range value may be 'open'.
-      Hypens mandatory when month is present. 
+      Hyphens mandatory when month is present. 
       -->
       <xs:pattern value="((-)?(\d{4}(-\d{2})?(-\d{2})?)|unknown)/((-)?(\d{4}(-\d{2})?(-\d{2})?)|unknown|open)" />
     </xs:restriction>

--- a/source/meta/kernel-4.4/metadata.xsd
+++ b/source/meta/kernel-4.4/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
   2010-08-26 Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
   2010-11-17 Revised to current state of kernel review, FZ, TIB
-  2011-01-17 Complete revsion after community review. FZ, TIB
+  2011-01-17 Complete revision after community review. FZ, TIB
   2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
   2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
   2013-07-24 v3.0: namespace: kernel-3.0; delete LastMetadataUpdate & MetadateVersionNumber; additions to controlled lists "contributorType", "dateType", "descriptionType", "relationType", "relatedIdentifierType" & "resourceType"; deletion of "StartDate" & "EndDate" from list "dateType" and "Film" from "resourceType";  allow arbitrary order of elements; allow optional wrapper elements to be empty; include xml:lang attribute for title, subject & description; include attribute schemeURI for nameIdentifier of creator, contributor & subject; added new attributes "relatedMetadataScheme", "schemeURI" & "schemeType" to relatedIdentifier; included new property "geoLocation"
@@ -161,7 +161,7 @@
             <xs:sequence>
               <xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
-                  <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+                  <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
                   <xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
@@ -641,19 +641,19 @@ Use the complete title of a license and include version information if applicabl
       <xs:pattern value="\d{2}(\d{2}|\?\?|\d(\d|\?))(-(\d{2}|\?\?))?~?\??" />
       <!--  
       The following pattern is for  yearMonthDay - yyyymmdd,  where 'dd' may be '??'  so '200412??' means "some day during the month of 12/2004". 
-      The whole  string may be followed by '?' or '~'  to mean "questionable" or "approximate".     Hypens are  not allowed for this pattern. 
+      The whole  string may be followed by '?' or '~'  to mean "questionable" or "approximate".     Hyphens are  not allowed for this pattern. 
       -->
       <xs:pattern value="\d{6}(\d{2}|\?\?)~?\??" />
       <!--  
 
       The following pattern is for date and time with T separator:'yyyymmddThhmmss'. 
-      Hypens in date and colons in time not allowed for this pattern.   
+      Hyphens in date and colons in time not allowed for this pattern.   
       -->
       <xs:pattern value="\d{8}T\d{6}" />
       <!--  
 
       The following pattern is for a date range. in years: 'yyyy/yyyy'; or year/month: yyyy-mm/yyyy-mm, or year/month/day: yyyy-mm-dd/yyyy-mm-dd. Beginning or end of range value may be 'unknown'. End of range value may be 'open'.
-      Hypens mandatory when month is present. 
+      Hyphens mandatory when month is present. 
       -->
       <xs:pattern value="((-)?(\d{4}(-\d{2})?(-\d{2})?)|unknown)/((-)?(\d{4}(-\d{2})?(-\d{2})?)|unknown|open)" />
     </xs:restriction>

--- a/source/meta/kernel-4/metadata.xsd
+++ b/source/meta/kernel-4/metadata.xsd
@@ -2,7 +2,7 @@
 <!-- Revision history
   2010-08-26 Complete revision according to new common specification by the metadata work group after review. AJH, DTIC
   2010-11-17 Revised to current state of kernel review, FZ, TIB
-  2011-01-17 Complete revsion after community review. FZ, TIB
+  2011-01-17 Complete revision after community review. FZ, TIB
   2011-03-17 Release of v2.1: added a namespace; mandatory properties got minLength; changes in the definitions of relationTypes IsDocumentedBy/Documents and isCompiledBy/Compiles; changes type of property "Date" from xs:date to xs:string. FZ, TIB
   2011-06-27 v2.2: namespace: kernel-2.2, additions to controlled lists "resourceType", "contributorType", "relatedIdentifierType", and "descriptionType". Removal of intermediate include-files.
   2013-07-24 v3.0: namespace: kernel-3.0; delete LastMetadataUpdate & MetadateVersionNumber; additions to controlled lists "contributorType", "dateType", "descriptionType", "relationType", "relatedIdentifierType" & "resourceType"; deletion of "StartDate" & "EndDate" from list "dateType" and "Film" from "resourceType";  allow arbitrary order of elements; allow optional wrapper elements to be empty; include xml:lang attribute for title, subject & description; include attribute schemeURI for nameIdentifier of creator, contributor & subject; added new attributes "relatedMetadataScheme", "schemeURI" & "schemeType" to relatedIdentifier; included new property "geoLocation"
@@ -161,7 +161,7 @@
             <xs:sequence>
               <xs:element name="contributor" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
-                  <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset.</xs:documentation>
+                  <xs:documentation>The institution or person responsible for collecting, creating, or otherwise contributing to the development of the dataset.</xs:documentation>
                   <xs:documentation>The personal name format should be: Family, Given.</xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
@@ -641,19 +641,19 @@ Use the complete title of a license and include version information if applicabl
       <xs:pattern value="\d{2}(\d{2}|\?\?|\d(\d|\?))(-(\d{2}|\?\?))?~?\??" />
       <!--  
       The following pattern is for  yearMonthDay - yyyymmdd,  where 'dd' may be '??'  so '200412??' means "some day during the month of 12/2004". 
-      The whole  string may be followed by '?' or '~'  to mean "questionable" or "approximate".     Hypens are  not allowed for this pattern. 
+      The whole  string may be followed by '?' or '~'  to mean "questionable" or "approximate".     Hyphens are  not allowed for this pattern. 
       -->
       <xs:pattern value="\d{6}(\d{2}|\?\?)~?\??" />
       <!--  
 
       The following pattern is for date and time with T separator:'yyyymmddThhmmss'. 
-      Hypens in date and colons in time not allowed for this pattern.   
+      Hyphens in date and colons in time not allowed for this pattern.   
       -->
       <xs:pattern value="\d{8}T\d{6}" />
       <!--  
 
       The following pattern is for a date range. in years: 'yyyy/yyyy'; or year/month: yyyy-mm/yyyy-mm, or year/month/day: yyyy-mm-dd/yyyy-mm-dd. Beginning or end of range value may be 'unknown'. End of range value may be 'open'.
-      Hypens mandatory when month is present. 
+      Hyphens mandatory when month is present. 
       -->
       <xs:pattern value="((-)?(\d{4}(-\d{2})?(-\d{2})?)|unknown)/((-)?(\d{4}(-\d{2})?(-\d{2})?)|unknown|open)" />
     </xs:restriction>

--- a/spec/kernel-4.1/geolocation_spec.rb
+++ b/spec/kernel-4.1/geolocation_spec.rb
@@ -169,7 +169,7 @@ describe "validate geoLocation" do
     expect(errors).to be_empty
   end
 
-  it 'geoLocationBox mising points' do
+  it 'geoLocationBox missing points' do
     element = doc.at("geoLocations")
     element.replace (<<-EOT)
       <geoLocations>

--- a/spec/kernel-4.2/geolocation_spec.rb
+++ b/spec/kernel-4.2/geolocation_spec.rb
@@ -169,7 +169,7 @@ describe "validate geoLocation" do
     expect(errors).to be_empty
   end
 
-  it 'geoLocationBox mising points' do
+  it 'geoLocationBox missing points' do
     element = doc.at("geoLocations")
     element.replace (<<-EOT)
       <geoLocations>

--- a/spec/kernel-4.3/geolocation_spec.rb
+++ b/spec/kernel-4.3/geolocation_spec.rb
@@ -169,7 +169,7 @@ describe "validate geoLocation" do
     expect(errors).to be_empty
   end
 
-  it 'geoLocationBox mising points' do
+  it 'geoLocationBox missing points' do
     element = doc.at("geoLocations")
     element.replace (<<-EOT)
       <geoLocations>

--- a/spec/kernel-4/geolocation_spec.rb
+++ b/spec/kernel-4/geolocation_spec.rb
@@ -169,7 +169,7 @@ describe "validate geoLocation" do
     expect(errors).to be_empty
   end
 
-  it 'geoLocationBox mising points' do
+  it 'geoLocationBox missing points' do
     element = doc.at("geoLocations")
     element.replace (<<-EOT)
       <geoLocations>


### PR DESCRIPTION
## Purpose

Make schema typos free

## Approach

codespell, automation via github actions to detect when typos are attempted to be introduced

#### Open Questions and Pre-Merge TODOs

Maybe should not be fixed retroactively?

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
