### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+# ignore-words-list = 

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = .git,*.pdf,*.svg
+skip = .git,*.pdf,*.svg,*v2.2.xml
 # ignore-words-list = 

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = .git,*.pdf,*.svg,*v2.2.xml
+skip = .git,*.pdf,*.svg,*v2.2.xml,kernel-4.[12345]*,kernel-3*
 # ignore-words-list = 

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = .git,*.pdf,*.svg,*v2.2.xml,kernel-4.[12345]*,kernel-3*
-ignore-regex = .*xml:lang="(?!en\b)[a-zA-Z]{2}".*|\bSimon Hart\b
+skip = .git,*.pdf,*.svg,*v2.2.xml,kernel-4.[012345]*,kernel-[123]*,xsd.xsl
+ignore-regex = .*xml:lang="(?!en\b)[a-zA-Z]{2}".*|\b(Simon Hart|GAGE)\b
 # ignore-words-list = 

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,4 @@
 [codespell]
 skip = .git,*.pdf,*.svg,*v2.2.xml,kernel-4.[12345]*,kernel-3*
+ignore-regex = .*xml:lang="(?!en\b)[a-zA-Z]{2}".*|\bSimon Hart\b
 # ignore-words-list = 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -473,7 +473,7 @@
 **Closed issues:**
 
 - add more tests [\#25](https://github.com/datacite/schema/issues/25)
-- Adressing version issues in the documentation [\#21](https://github.com/datacite/schema/issues/21)
+- Addressing version issues in the documentation [\#21](https://github.com/datacite/schema/issues/21)
 - Update Citation in Documentation [\#20](https://github.com/datacite/schema/issues/20)
 - integrate testing of non-valid example [\#12](https://github.com/datacite/schema/issues/12)
 - provide changelog for schema versions [\#9](https://github.com/datacite/schema/issues/9)
@@ -522,7 +522,7 @@
 **Closed issues:**
 
 - make html pages valid [\#24](https://github.com/datacite/schema/issues/24)
-- Chage wording in documentation [\#15](https://github.com/datacite/schema/issues/15)
+- Change wording in documentation [\#15](https://github.com/datacite/schema/issues/15)
 
 ## [v.3.1.12](https://github.com/datacite/schema/tree/v.3.1.12) (2016-01-10)
 

--- a/source/meta/kernel-4/example/datacite-example-multilingual-v4.xml
+++ b/source/meta/kernel-4/example/datacite-example-multilingual-v4.xml
@@ -31,7 +31,7 @@
         <date dateType="Available">2024-01-01</date>
     </dates>      
     <descriptions>
-        <description xml:lang="en" descriptionType="Abstract">This chapter reviews selected landmarks ocurred in Chemistry basic research in the last 5 years</description>
+        <description xml:lang="en" descriptionType="Abstract">This chapter reviews selected landmarks occurred in Chemistry basic research in the last 5 years</description>
         <description xml:lang="es" descriptionType="Abstract">El capítulo repasa los principales avances en la investigación básica en Ciencias Químicas en los últimos 5 años</description>
         <description xml:lang="zh" descriptionType="Abstract">本章回顾了过去5年中在化学基础研究中发生的一些里程碑式的事件</description>
     </descriptions>      


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

This is reincarnation of the
- #122 which was not considered for "We are not able to make schema changes retroactively"

In this PR I added exclusion for prior versions of schema.  It was tuned up on 
- #144 

which if merged into this PR leads to detection of the typo this PR fixes in `kernel-4/` (I guess which should be a copy of `kernel-4.6/` when released?)

```shell
❯ codespell -C 0
>         <description xml:lang="en" descriptionType="Abstract">This chapter reviews selected landmarks ocurred in Chemistry basic research in the last 5 years</description>
./source/meta/kernel-4.6/example/datacite-example-multilingual-v4.xml:34: ocurred ==> occurred
```

typo reiterating on utility of such an instrument like codespell to avoid typos sneaking in and then multiplicated.
